### PR TITLE
some go style updates

### DIFF
--- a/paneless.go
+++ b/paneless.go
@@ -28,9 +28,9 @@ func onReady() {
 			for {
 				i := systray.AddMenuItem(p.Name, "Rearrange the windows according to this preference")
 				<-i.ClickedCh
-				SetWindowPositions(p)
+				p.SetPositions()
 			}
-		}
+		}()
 	}
 
 	systray.AddSeparator()

--- a/window_preferences.go
+++ b/window_preferences.go
@@ -19,9 +19,12 @@ type WindowPreference struct {
 	Cy                int32
 }
 
-// ToJSONFile writes a *[]WindowPreferences to the input file name, creating it if it doesn't exist.
-func ToJSONFile(preferences *[]WindowPreferences, filename string) error {
-	data, err := json.MarshalIndent(preferences, "", "    ")
+// WindowPreferencesList list of window prefs
+type WindowPreferencesList []WindowPreferences
+
+// ToFile writes a WindowPreferencesList to the input file name in json, creating it if it doesn't exist.
+func (w *WindowPreferencesList) ToFile(filename string) error {
+	data, err := json.MarshalIndent(w, "", "    ")
 	if err != nil {
 		return err
 	}
@@ -34,18 +37,17 @@ func ToJSONFile(preferences *[]WindowPreferences, filename string) error {
 	return nil
 }
 
-// FromJSONFile reads the input file and attempts to unmarshal the contents into a *[]WindowPreferences.
-func FromJSONFile(filename string) (*[]WindowPreferences, error) {
+// FromFile reads the input file from json and attempts to unmarshal the contents into itself.
+func (w *WindowPreferencesList) FromFile(filename string) error {
 	data, err := ioutil.ReadFile(filename)
 	if err != nil {
-		return nil, err
+		return err
 	}
 
-	var windowPreferences []WindowPreferences
-	err = json.Unmarshal(data, &windowPreferences)
+	err = json.Unmarshal(data, w)
 	if err != nil {
-		return nil, err
+		return err
 	}
 
-	return &windowPreferences, nil
+	return nil
 }


### PR DESCRIPTION
Another note that ended up not being relevant because i refactored the list of windo prefs into a struct:
> slices and maps in go are reference types, so you don't need to pass around pointers to them.
> If you really were concerned with copy pasting things and WindowPeferences were a large struct,
> you could make this []*WindowPreferences but that's probably overkill in this case